### PR TITLE
Fix spurious WP after Murk spawn

### DIFF
--- a/F3_PA-examplescripts.Altis/murk/murk_spawn.sqf
+++ b/F3_PA-examplescripts.Altis/murk/murk_spawn.sqf
@@ -404,6 +404,13 @@ _fnc_spawnUnit = {
 
         private ["_i"]; _i = 0;
  
+ 	// Delete all existing waypoints
+	// This fixes the "Mysterious [0,0] (bottom left corner of the map) WP
+	// from nowhere" bug
+	while {(count (waypoints _newGroup)) > 0} do {
+		deleteWaypoint ((waypoints _newGroup) select 0);
+	};
+
         //Let's return them their waypoints
         {
                 //diag_log format ["All data : %1",_x];


### PR DESCRIPTION
When using Murk spawns, often (but not always), units would get a
spurious waypoint at [0,0] (bottom left corner of the map). On maps like
Altis, Stratis and Tanoa, this is not a problem, since that location is
the middle of the ocean and so the AI doesn't even try to get there.

On Maps like Takistan, where the point is reachable, AI would head there
after any preplaced waypoints had been reached, necessitating that
mission makers add dummy "HOLD" waypoints to all units that are meant to
stay where they spawn. Furthermore, units that survived visiting all of
their waypoints would still end up going to [0,0] afterwards.

The fix is to delete all existing waypoints in Murk spawn, just before
replacing the saved ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/captainblaffer/f3_pa/5)
<!-- Reviewable:end -->
