### PR TITLE
Fix assignGear for Grenadiers

### DIFF
--- a/F3_PA-examplescripts.Altis/mission.sqm
+++ b/F3_PA-examplescripts.Altis/mission.sqm
@@ -20627,7 +20627,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_ASL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_ASL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_A2_G";
 						description="NATO Alpha 2 Grenadier";
 						isPlayable=1;
@@ -21148,7 +21148,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_BSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_BSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_B2_G";
 						description="NATO Bravo 2 Grenadier";
 						isPlayable=1;
@@ -21626,7 +21626,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_CSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_CSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_C2_G";
 						description="NATO Charlie 2 Grenadier";
 						isPlayable=1;
@@ -22146,7 +22146,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_DSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_DSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_D2_G";
 						description="NATO Delta 2 Grenadier";
 						isPlayable=1;
@@ -22667,7 +22667,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_ESL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_ESL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_E2_G";
 						description="NATO Echo 2 Grenadier";
 						isPlayable=1;

--- a/F3_PA-master.Altis/mission.sqm
+++ b/F3_PA-master.Altis/mission.sqm
@@ -11263,7 +11263,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_ASL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_ASL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_A2_G";
 						description="NATO Alpha 2 Grenadier@Alpha";
 						isPlayable=1;
@@ -11783,7 +11783,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_BSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_BSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_B2_G";
 						description="NATO Bravo 2 Grenadier@Bravo";
 						isPlayable=1;
@@ -12261,7 +12261,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_CSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_CSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_C2_G";
 						description="NATO Charlie 2 Grenadier@Charlie";
 						isPlayable=1;
@@ -12781,7 +12781,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_DSL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_DSL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_D2_G";
 						description="NATO Delta 2 Grenadier@Delta";
 						isPlayable=1;
@@ -13301,7 +13301,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="GrpNATO_ESL = group this; [""g"",this] call f_fnc_assignGear;";
+						init="GrpNATO_ESL = group this; [""gren"",this] call f_fnc_assignGear;";
 						name="UnitNATO_E2_G";
 						description="NATO Echo 2 Grenadier@Echo";
 						isPlayable=1;


### PR DESCRIPTION
The framework uses "gren" as the unit type for assignGear[0], but the
missions used "g". Switch the mission to also use "gren", since it's not
like we have to type it often, and "gren" is easier to understand
without context.

[0] cf. f/assignGear/f_assignGear_nato.sqf:822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/captainblaffer/f3_pa/8)
<!-- Reviewable:end -->
