### PR TITLE
Change default setup for respawn to not use Spectator

### DIFF
--- a/F3_PA-examplescripts.Altis/description.ext
+++ b/F3_PA-examplescripts.Altis/description.ext
@@ -51,7 +51,9 @@ enableDebugConsole = 1;
 respawn = 3; //Suggested NOT to change this
 respawndelay = 4;
 respawnOnStart = 0;
-respawnTemplates[] = {"f_JIP","f_spectator"};	// remove "f_spectator" when using respawn.
+// Uncomment the first line (delete the second) for Spectator-on-Respawn
+//respawnTemplates[] = {"f_JIP","f_spectator"};
+respawnTemplates[] = {"f_JIP""};
 respawnDialog = 0;
 
 // ============================================================================================

--- a/F3_PA-examplescripts.Altis/init.sqf
+++ b/F3_PA-examplescripts.Altis/init.sqf
@@ -193,7 +193,8 @@ f_wound_extraFAK = 2;
 // F3 - JIP setup (PA version)
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-// Note: if you want respawn, go to description.ext and remove "f_spectator" from respawnTemplates[]
+// Note: if you *don't* want respawn (and spectator instead), go to description.ext and follow the instructions there (look
+// for f_spectator)
 // Note: respawn_west etc. markers are mandatory. When not using respawn, place these markers somewhere players will not go
 f_var_JIP_JIPMenu = true;		// Do JIP players get the JIP menu?
 f_var_JIP_RespawnMenu = false;	// Do respawning players get the JIP menu? 

--- a/F3_PA-master.Altis/description.ext
+++ b/F3_PA-master.Altis/description.ext
@@ -51,7 +51,9 @@ enableDebugConsole = 1;
 respawn = 3; //Suggested NOT to change this
 respawndelay = 4;
 respawnOnStart = 0;
-respawnTemplates[] = {"f_JIP","f_spectator"};	// remove "f_spectator" when using respawn.
+// Uncomment the first line (delete the second) for Spectator-on-Respawn
+//respawnTemplates[] = {"f_JIP","f_spectator"};
+respawnTemplates[] = {"f_JIP""};
 respawnDialog = 0;
 
 // ============================================================================================

--- a/F3_PA-master.Altis/init.sqf
+++ b/F3_PA-master.Altis/init.sqf
@@ -193,7 +193,8 @@ f_wound_extraFAK = 2;
 // F3 - JIP setup (PA version)
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)
 
-// Note: if you want respawn, go to description.ext and remove "f_spectator" from respawnTemplates[]
+// Note: if you *don't* want respawn (and spectator instead), go to description.ext and follow the instructions there (look
+// for f_spectator)
 // Note: respawn_west etc. markers are mandatory. When not using respawn, place these markers somewhere players will not go
 f_var_JIP_JIPMenu = true;		// Do JIP players get the JIP menu?
 f_var_JIP_RespawnMenu = false;	// Do respawning players get the JIP menu?


### PR DESCRIPTION
I can't count how many times I've had people ask for help with respawn
when the only thing missing was this line being edited. We *very* rarely
use spectator mode, so let's not make it the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/captainblaffer/f3_pa/9)
<!-- Reviewable:end -->
